### PR TITLE
Requires Ruby 2.4+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
 
       matrix:
         ruby:
-          - "2.2"
-          - "2.3"
           - "2.4"
           - "2.5"
           - "2.6"
@@ -41,17 +39,8 @@ jobs:
           - rails_7_0
           - rails_7_1
 
-        include:
-          # ref. https://github.com/ruby/setup-ruby/issues/496#issuecomment-1520662740
-          - ruby: "2.2"
-            runner: ubuntu-20.04
-
         exclude:
           # Rails 6.0+ requires Ruby 2.5+
-          - ruby:    "2.2"
-            gemfile: rails_6_0
-          - ruby:    "2.3"
-            gemfile: rails_6_0
           - ruby:    "2.4"
             gemfile: rails_6_0
           - ruby:    "2.2"
@@ -62,10 +51,6 @@ jobs:
             gemfile: rails_6_1
 
           # Rails 7.0+ requires Ruby 2.7+
-          - ruby:    "2.2"
-            gemfile: rails_7_0
-          - ruby:    "2.3"
-            gemfile: rails_7_0
           - ruby:    "2.4"
             gemfile: rails_7_0
           - ruby:    "2.5"

--- a/chatwork_webhook_verify.gemspec
+++ b/chatwork_webhook_verify.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.description = "Verify ChatWork webhook signature"
   s.license     = "MIT"
 
+  s.required_ruby_version = ">= 2.4"
+
   s.metadata["homepage_uri"] = s.homepage
   s.metadata["source_code_uri"] = s.homepage
   s.metadata["changelog_uri"] = "#{s.homepage}/blob/master/CHANGELOG.md"


### PR DESCRIPTION
`Base64.decode64` uses `String#unpack1`
https://github.com/ruby/base64/blob/v0.2.0/lib/base64.rb#L241-L243

But `String#unpack1` is available since Ruby 2.4+

Ruby 2.3 is already EOL, so I dropped.

Close #63